### PR TITLE
Add Rust port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Members of the community have graciously created implementations of this library
 | [runeterra](https://github.com/SwitchbladeBot/runeterra) | JavaScript | 1 | SwitchbladeBot |
 | [lordeckoder](https://github.com/MarekSalgovic/lordeckoder) | Golang | 1 | MarekSalgovic |
 | [PyLoRDeckCodes](https://github.com/Bamiji/PyLoRDeckCodes) | Python 3 | 1 | Bamiji |
+| [lordeckcodes-rs](https://github.com/iulianR/lordeckcodes-rs) | Rust | 1 | iulianR |
 
 *Version refers to the MAX_KNOWN_VERSION supported by the implementation.
 


### PR DESCRIPTION
Hello, I have created a Rust implementation of this library:
* Repository - https://github.com/iulianR/lordeckcodes-rs
* crates.io (package registry) - https://crates.io/crates/lordeckcodes
* documentation - https://docs.rs/lordeckcodes/0.1.0/lordeckcodes/
* Tests run (all tests found in the C# implementation)
```
running 14 tests
test bad_count ... ok
test bad_card_codes ... ok
test basic_encode_test ... ok
test deck_with_counts_more_than_3_small ... ok
test basic_decode_test ... ok
test garbage_decoding ... ok
test order_should_not_matter_2 ... ok
test single_card_40_times ... ok
test large_deck ... ok
test order_should_not_matter_1 ... ok
test deck_with_more_than_3_large ... ok
test small_deck ... ok
test worst_case_length ... ok
test encode_decode_recommended ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

It would be great if this implementation could be added to the list found in the README.md. Thank you!
