### PR TITLE
Remove python3 implementation link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Members of the community have graciously created implementations of this library
 | [LoRDeckCodesPython](https://github.com/Rafalonso/LoRDeckCodesPython) | Python 3 | 1 | Rafalonso |
 | [runeterra](https://github.com/SwitchbladeBot/runeterra) | JavaScript | 1 | SwitchbladeBot |
 | [lordeckoder](https://github.com/MarekSalgovic/lordeckoder) | Golang | 1 | MarekSalgovic |
-| [PyLoRDeckCodes](https://github.com/Bamiji/PyLoRDeckCodes) | Python 3 | 1 | Bamiji |
 | [RuneTerraPHP](https://github.com/mike-reinders/runeterra-php) | PHP 7.2 | 1 | Mike-Reinders |
 | [LoRDeckCodes.jl](https://github.com/wookay/LoRDeckCodes.jl) | Julia | 1 | wookay |
 | [lordeckcodes-rs](https://github.com/iulianR/lordeckcodes-rs) | Rust | 1 | iulianR |


### PR DESCRIPTION
I am requesting removal of my name and associated row from the mockery that is the readme's current ordering. As my reward for taking time and effort out to end up submitting the [first](https://i.gyazo.com/2695788ee4bf10326bc0a1ce1ebe0633.png) language [port](https://i.gyazo.com/01bd3bb9964ad4d2f2137c6e46c29f73.png) of the encoder/decoder, Riot has [apparently decided](https://github.com/RiotGames/LoRDeckCodes/pull/15#issuecomment-544744556) that just treatment is to place my name [several spaces below](https://gyazo.com/41ecb2aef80e6f2fbe864b05a2add7eb.png) someone creating a duplicate port for the same language about a [whole day](https://i.gyazo.com/b9fa347f6fcd7251dcec15490b77c8a6.png) after me?

The reasoning for this being that the re-submission order is to be respected above everything else, because..? Is it too much to ask them expend slightly more effort into seeing that the implication of any substantial change being performed on the submissions after submission format specification is untrue? Since otherwise I see no reason to so blatantly spit in the face of the true submission order to adhere to a faux scheme in its place, as far as those who submitted prior to the format's definition are concerned.

If you wish, you can call me overly self-absorbed to ask for simple fairness on this issue, go right ahead. It's nice to know that all the niceties [sprinkled generously](https://github.com/RiotGames/LoRDeckCodes/pull/4#issuecomment-543984531) into responses were not more than hollow PR speak, since I find it hard to feel any appreciation in the misrepresentation that would have it look like *I* submitted an unnecessary duplicate port of an already done language much later, when in truth I was the first in more ways than one.  This is to be equated to gratitude and thanks? Rather, I would get the impression of carelessness. The irony here of course being the strict adherence to order of submission is present, just woefully misplaced on another order that represents nothing meaningful as far as order is concerned.

In addition, messages were sent with hopes to resolve the unwarranted treatment or at the least hear more, if any, justification for the baseless fixed stance. But I was simply met with ignorance since Monday till now, as though a common troll. This being the cherry on the cake of their developer appreciation after my repository had already been absorbed into their implementations list.

It's hard not to get the feeling that, if just because my language of choice was retroactively duplicated, I could not matter any less to those managing this repository.

As of now, I have already deleted my repository for this on my own, since I have been trained to doubt I'll be further responded to in the handling of this issue, seemingly not being worth any level of respect from Riot. But assuming ideals can still exist, I again request that my name also be taken down. In any case, you will otherwise be left with a broken link.