### PR TITLE
Add TypeScript port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Members of the community have graciously created implementations of this library
 | [lordeckcodes-rs](https://github.com/iulianR/lordeckcodes-rs) | Rust | 1 | iulianR |
 | [twisted_fate](https://github.com/snowcola/twisted_fate) | Python 3 | 1 | snowcola |
 | [LoRDeckCodes](https://github.com/Pole458/LoRDeckCodesAndroid) | Android | 1 | Pole |
+| [lor-deckcode](https://github.com/icepeng/lor-deckcode) | TypeScript | 1 | icepeng |
 
 *Version refers to the MAX_KNOWN_VERSION supported by the implementation.
 


### PR DESCRIPTION
Hello, I have created TypeScript implementation of LoR Deckcode.

[Repo](https://github.com/icepeng/lor-deckcode)

```
 PASS  src/decode.spec.ts
 PASS  src/encode.spec.ts

Test Suites: 2 passed, 2 total
Tests:       42 passed, 42 total
Snapshots:   0 total
Time:        0.631s, estimated 2s
Ran all test suites.
```

Tests run (found in https://github.com/RiotGames/LoRDeckCodes/blob/master/LoRDeckCodes_Tests/DeckCodesTestData.txt)