### PR TITLE
Add Ruby port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Members of the community have graciously created implementations of this library
 | [twisted_fate](https://github.com/snowcola/twisted_fate) | Python 3 | 1 | snowcola |
 | [LoRDeckCodes](https://github.com/Pole458/LoRDeckCodesAndroid) | Android | 1 | Pole |
 | [lor-deckcode](https://github.com/icepeng/lor-deckcode) | TypeScript | 1 | icepeng |
+| [CardGameFr-LoRDeckCode](https://github.com/Yohan-Frmt/CardGameFr-LoRDeckCode) | Ruby | 1 | Yohan-Frmt |
 
 *Version refers to the MAX_KNOWN_VERSION supported by the implementation.
 


### PR DESCRIPTION
Hey, here is a Ruby implementation of LoRDeckCodes