### PR TITLE
Add Swift implementation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Members of the community have graciously created implementations of this library
 | [CardGameFr-LoRDeckCode](https://github.com/Yohan-Frmt/CardGameFr-LoRDeckCode) | Ruby | 1 | Yohan-Frmt |
 | [LoRDeckCoder](https://github.com/Paul1365972/LoRDeckCoder) | Java 8 | 1 | Paul1365972 |
 | [lor_deck_codes_dart](https://github.com/edenizk/lor_deck_codes_dart) | Dart | 1 | edenizk |
+| [lor-deckcodes](https://github.com/tomaszbak/lor-deckcodes) | Swift | 1 | tomaszbak |
 
 *Version refers to the MAX_KNOWN_VERSION supported by the implementation.
 


### PR DESCRIPTION
I've created a Swift implementation of the decoder and added a reference to the "Implementations" table.