### PR TITLE
Bump runeterra version to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Members of the community have graciously created implementations of this library
 | --------------------- | -------- | -------- | ---------- |
 | [LoRDeckCodes](https://github.com/stelar7/LoRDeckCodes) | Java 8 | 1 | stelar7 |
 | [LoRDeckCodesPython](https://github.com/Rafalonso/LoRDeckCodesPython) | Python 3 | 2 | Rafalonso |
-| [runeterra](https://github.com/SwitchbladeBot/runeterra) | JavaScript | 1 | SwitchbladeBot |
+| [runeterra](https://github.com/SwitchbladeBot/runeterra) | JavaScript | 2 | SwitchbladeBot |
 | [lordeckoder](https://github.com/MarekSalgovic/lordeckoder) | Golang | 1 | MarekSalgovic |
 | [RuneTerraPHP](https://github.com/mike-reinders/runeterra-php) | PHP 7.2 | 1 | Mike-Reinders |
 | [LoRDeckCodes.jl](https://github.com/wookay/LoRDeckCodes.jl) | Julia | 1 | wookay |


### PR DESCRIPTION
I've just pushed an update to [runeterra](https://github.com/SwitchbladeBot/runeterra) that adds Bilgewater support and bumps `MAX_KNOWN_VERSION` to 2. This Pull Request updates our entry on the list to reflect that.