### PR TITLE
bump MAX_SUPPORTED_VERSION for twisted_fate

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Members of the community have graciously created implementations of this library
 | [RuneTerraPHP](https://github.com/mike-reinders/runeterra-php) | PHP 7.2 | 2 | Mike-Reinders |
 | [LoRDeckCodes.jl](https://github.com/wookay/LoRDeckCodes.jl) | Julia | 1 | wookay |
 | [lordeckcodes-rs](https://github.com/iulianR/lordeckcodes-rs) | Rust | 1 | iulianR |
-| [twisted_fate](https://github.com/snowcola/twisted_fate) | Python 3 | 1 | snowcola |
+| [twisted_fate](https://github.com/snowcola/twisted_fate) | Python 3 | 2 | snowcola |
 | [LoRDeckCodes](https://github.com/Pole458/LoRDeckCodesAndroid) | Android | 1 | Pole |
 | [lor-deckcode](https://github.com/icepeng/lor-deckcode) | TypeScript | 1 | icepeng |
 | [CardGameFr-LoRDeckCode](https://github.com/Yohan-Frmt/CardGameFr-LoRDeckCode) | Ruby | 1 | Yohan-Frmt |


### PR DESCRIPTION
Change version to 2 for twisted_fate as it now supports Bilgewater.