### PR TITLE
Update Implementations section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Members of the community have graciously created implementations of this library
 | [LoRDeckCoder](https://github.com/Paul1365972/LoRDeckCoder) | Java 8 | 1 | Paul1365972 |
 | [lor_deck_codes_dart](https://github.com/edenizk/lor_deck_codes_dart) | Dart | 2 | edenizk |
 | [lor_deckcodes_dart](https://github.com/exts/lor_deckcodes_dart) | Dart 2 | 2** | exts |
-| [lor-deckcodes](https://github.com/tomaszbak/lor-deckcodes) | Swift | 1 | tomaszbak |
+| [lor-deckcodes](https://github.com/tomaszbak/lor-deckcodes) | Swift | 2** | tomaszbak |
 | [ForDeckmacia](https://github.com/Billzabob/ForDeckmacia) | Scala | 2** | Billzabob |
 | [LoRDeck++](https://github.com/EvanKaraf/LoRDeckpp) | C++ | 2 | EvanKaraf |
 | [runeterra_cards](https://github.com/zofrex/runeterra_cards) | Ruby | 2** | zofrex |


### PR DESCRIPTION
Swift implementation have been just updated to 0.3.0 with Bilgewater support.