### PR TITLE
Update ForDeckmacia to Version 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Members of the community have graciously created implementations of this library
 
 | Name                  | Language | Version* | Maintainer |
 | --------------------- | -------- | -------- | ---------- |
+| [ForDeckmacia](https://github.com/Billzabob/ForDeckmacia) | Scala | 4 | Billzabob |
 | [R4J](https://github.com/stelar7/R4J) | Java 8 | 3 | stelar7 |
 | [LoRDeckCodesPython](https://github.com/Rafalonso/LoRDeckCodesPython) | Python 3 | 3 | Rafalonso |
 | [runeterra](https://github.com/SwitchbladeBot/runeterra) | JavaScript | 3 | SwitchbladeBot |
@@ -86,7 +87,6 @@ Members of the community have graciously created implementations of this library
 | [lordeckcodes-rs](https://github.com/iulianR/lordeckcodes-rs) | Rust | 3 | iulianR |
 | [LoRDeckCodes](https://github.com/Pole458/LoRDeckCodesAndroid) | Android | 3 | Pole |
 | [lor_deck_codes_dart](https://github.com/edenizk/lor_deck_codes_dart) | Dart | 3 | edenizk |
-| [ForDeckmacia](https://github.com/Billzabob/ForDeckmacia) | Scala | 3 | Billzabob |
 | [runeterra_cards](https://github.com/zofrex/runeterra_cards) | Ruby | 3 | zofrex |
 | [runeterra_decks](https://github.com/SolitudeSF/runeterra_decks) | Nim | 3 | SolitudeSF |
 | [lor-deckcodes-ts](https://github.com/jcuker/lor-deckcode-ts) | TypeScript | 3 | jcuker |


### PR DESCRIPTION
I have added support for Bandle City (BC, 10) to my library. I've also made the change to encode the deck with the lowest version number it can, depending on the regions in the deck.