### PR TITLE
Update Go implementations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Members of the community have graciously created implementations of this library
 | [runeterra_decks](https://github.com/SolitudeSF/runeterra_decks) | Nim | 5 | SolitudeSF |
 | [lor-deckcodes-ts](https://github.com/jcuker/lor-deckcode-ts) | TypeScript | 5 | jcuker |
 | [lordecks](https://github.com/pholzmgit/lordecks) | R | 5 | pholzmgit |
-| [goterra](https://github.com/sousa-andre/goterra) | Golang | 4 | sousa-andre |
+| [lor-deckcode-go](https://github.com/m0t0k1ch1/lor-deckcode-go) | Go | 5 | m0t0k1ch1 |
 | [lor-deckcodes](https://github.com/tomaszbak/lor-deckcodes) | Swift | 4 | tomaszbak |
 | [runeterra-deck-code](https://github.com/Yutsa/runeterra-deck-code) | Java | 4 | Yutsa |
 | [riot_lor](https://github.com/ed-flanagan/riot_lor) | Elixir | 5 | ed-flanagan |
@@ -105,10 +105,11 @@ Leading up to the release of a new version of the library, we'll keep the origin
 
 | Name                  | Language | Version* | Maintainer |
 | --------------------- | -------- | -------- | ---------- |
+| [lordeckoder](https://github.com/MarekSalgovic/lordeckoder) | Go | 4 | MarekSalgovic |
+| [goterra](https://github.com/sousa-andre/goterra) | Go | 4 | sousa-andre |
 | [LoRDeckCodes.jl](https://github.com/wookay/LoRDeckCodes.jl) | Julia | 3 | wookay |
 | [twisted_fate](https://github.com/snowcola/twisted_fate) | Python 3 | 2** | snowcola |
 | [lor_deckcodes_dart](https://github.com/exts/lor_deckcodes_dart) | Dart 2 | 2** | exts |
-| [lordeckoder](https://github.com/MarekSalgovic/lordeckoder) | Golang | 2 | MarekSalgovic |
 | [lor-deckcode](https://github.com/icepeng/lor-deckcode) | TypeScript | 2 | icepeng |
 | [LoRDeck++](https://github.com/EvanKaraf/LoRDeckpp) | C++ | 2 | EvanKaraf |
 | [LorElixir](https://github.com/petter-kaspersen/lor-deck-codes-elixir) | Elixir | 1 | petter-kaspersen |


### PR DESCRIPTION
- Add [lor-deckcode-go](https://github.com/m0t0k1ch1/lor-deckcode-go) to the **Current Versions** section
- Update the [lordeckoder](https://github.com/MarekSalgovic/lordeckoder) supported version to 4
  - ref. https://github.com/MarekSalgovic/lordeckoder/commit/012e109ea328b5ffbbe161aaf9201bca63c38b06
- Move [goterra](https://github.com/sousa-andre/goterra) to the **Previous Versions** section
  - In addition, goterra has the following problems:
    - No sorting when encoding
    - Wrong varint encoding
    - Insufficient error handling
    - ...
