### PR TITLE
Add patched-porobot as Rust deck code library

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Members of the community have graciously created implementations of this library
 | [lor-deckcode-go](https://github.com/m0t0k1ch1/lor-deckcode-go) | Go | 5 | m0t0k1ch1 |
 | [LorDeckCodeCpp](https://github.com/Suolumi/LorDeckCodeCpp) | C++ | 5 | Suolumi |
 | [Kunc.RiotGames.Lor.DeckCodes](https://github.com/AoshiW/Kunc.RiotGames) | C# | 5 | AoshiW |
+| [patched-porobot](https://github.com/Steffo99/patched-porobot) | Rust | 5 | Steffo99 |
 
 
 Leading up to the release of a new version of the library, we'll keep the original and new version in the **Current Version** section. A couple weeks after the release of a new version, any libraries that have not been updated to the latest version will be moved into the **Previous Versions** section. Any libraries in the **Previous Version** section that get updated to the latest version will get appended to the **Current Version** section.


### PR DESCRIPTION
I made a deck code library for Rust, and two associated Telegram and Discord bots.

https://github.com/Steffo99/patched-porobot